### PR TITLE
Feature/core modifications

### DIFF
--- a/etc/bootstrap.sql
+++ b/etc/bootstrap.sql
@@ -3,39 +3,75 @@ drop table job CASCADE;
 create table job
 (
     id serial primary key,
+    metric_alias varchar(100) not null,
+    range_query varchar(255),
     prometheus_url varchar(255) not null,
-    metric varchar(255) not null,
-    query_filter varchar(512),
-    range_function varchar(10) check
-        (upper(range_function) in ('RATE','IRATE','INCREASE')),
-    optimize_function varchar(10) check
-        (upper(optimize_function) in ('MSE','RMSE','MAE','MAPE','MDAPE')),
     forecast_horizon varchar(4) not null check
         (forecast_horizon in ('1h','6h','12h','1d','7d','30d','90d','180d','365d')),
-    forecast_frequency varchar(4) not null check
+    forecast_frequency varchar(2) not null check
         (forecast_frequency in ('5m','10m','1h','3h','1d')),
-    status varchar(32) not null check
+    optimize_function varchar(5) check
+        (upper(optimize_function) in ('MSE','RMSE','MAE','MAPE','MDAPE')),
+    status varchar(10) not null check
         (status in ('FETCHING','NEW','RUNNING','ERROR','FINISHED','DISABLED')),
     last_run timestamp with time zone default null,
     next_run timestamp with time zone default null,
-    last_run_duration integer,
-    last_validation timestamp  with time zone default null
+    last_run_duration integer
 );
+comment on column job.metric_alias is 'Metric alias, used as a part of forecast metrics name';
+comment on column job.range_query is 'Primary PromQL query';
 comment on column job.prometheus_url is 'Prometheus API url with metrics to fetch';
-comment on column job.metric is 'Metric name';
-comment on column job.query_filter is 'PromQL filter query';
-comment on column job.range_function is 'PromQL range function. Use only for counters. Available options: IRATE, RATE, INCREASE';
-comment on column job.optimize_function is 'KPI for hyper parameters tuning. Options: MSE, RMSE, MAE, MAPE, MDAPE. Use wisely';
 comment on column job.forecast_horizon is 'Horizon of forecast. Available options: 1h, 6h, 12h, 1d, 7d, 30d, 90d, 180d, 365d';
 comment on column job.forecast_frequency is 'Frequency of forecast. Available options: 5m, 10m, 1h, 3h, 1d';
-comment on column job.status is 'Current status of the job. Available options: FETCHING, NEW, RUNNING, ERROR, FINISHED, DISABLED';
+comment on column job.optimize_function is 'KPI for hyper parameters tuning. Options: MSE, RMSE, MAE, MAPE, MDAPE. Use wisely';
+comment on column job.status is 'Current status of the job. Available options: NEW, FETCHING, RUNNING, ERROR, FINISHED, DISABLED';
 comment on column job.last_run is 'Date of job last run';
 comment on column job.next_run is 'Date of job next run';
 comment on column job.last_run_duration is 'Elapsed time of last job execution in seconds';
-comment on column job.last_validation is 'Date of last hyper parameters tuning';
+
+
+insert into job values (
+    default,
+    'node_cpu_seconds_total:sum_mode:increase:5m',
+    'sum(increase(node_cpu_seconds_total{mode=~".*"}[5m])) by (mode)',
+    'http://localhost:9090/',
+    '1h',
+    '5m',
+    null,
+    'NEW',
+    null,
+    null,
+    null);
+
+
+
+create table optimizer_findings
+(
+    ins_time timestamp with time zone not null default now(),
+    status varchar(10) not null check
+        (status in ('NEW','RUNNING','ACTUAL','STALE')),
+    job_id integer not null,
+    metric_labels varchar(512),
+    optimize_function varchar(5),
+    changepoint_prior_scale real,
+    seasonality_prior_scale real,
+    holiday_prior_scale real,
+    run_duration integer
+);
+comment on column optimizer_findings.ins_time is 'Model evaluation date';
+comment on column optimizer_findings.status is 'Status of optimizer task. Available options: NEW, FETCHING, RUNNING, ACTUAL, STALE';
+comment on column optimizer_findings.job_id is 'Job Id';
+comment on column optimizer_findings.metric_labels is 'Timeseries labels';
+comment on column optimizer_findings.optimizer_findings is 'KPI function used to optimize a model';
+comment on column optimizer_findings.changepoint_prior_scale is 'current best value of changepoint_prior_scale parameter';
+comment on column optimizer_findings.seasonality_prior_scale is 'current best value of seasonality_prior_scale parameter';
+comment on column optimizer_findings.holiday_prior_scale is 'current best value of holiday_prior_scale parameter';
+comment on column optimizer_findings.run_duration is 'elapsed seconds';
+
 
 create table forecast
 (
+    ins_time timestamp with time zone not null default now(),
     ds_from timestamp with time zone not null,
     ds_to timestamp with time zone not null,
     job_id integer not null,
@@ -45,9 +81,10 @@ create table forecast
     yhat_upper real not null,
     FOREIGN KEY (job_id) REFERENCES job(id)
 );
-comment on column forecast.ds_from is 'Begining of forecast interval';
+comment on column forecast.ins_time is 'Modification date';
+comment on column forecast.ds_from is 'Beginning of forecast interval';
 comment on column forecast.ds_to is 'End of forecast interval';
-comment on column forecast.job_id is 'Job id';
+comment on column forecast.job_id is 'Job Id';
 comment on column forecast.metric_labels is 'Labels for forecasted timeseries';
 comment on column forecast.yhat is 'Forecast';
 comment on column forecast.yhat_lower is 'Lower margin of the Forecast';
@@ -56,6 +93,7 @@ comment on column forecast.yhat_upper is 'Upper margin of the Forecast';
 create table train_data
 (
     id serial primary key,
+    ins_time timestamp with time zone not null default now(),
     job_id integer not null,
     status varchar(32) not null default 'NEW'
         check (status in ('NEW','RUNNING','FINISHED','ERROR')),
@@ -64,21 +102,9 @@ create table train_data
     data text,
     FOREIGN KEY (job_id) REFERENCES job(id)
 );
+comment on column train_data.ins_time is 'Modification date';
+comment on column train_data.job_id is 'Job Id';
 comment on column train_data.status is 'Status of forecasting timeseries. Available options: NEW, RUNNING, FINISHED, ERROR';
 comment on column train_data.created_time is 'Time when series were loaded';
 comment on column train_data.updated_time is 'Time when task was updated';
 comment on column train_data.data is 'Values of historic timeseries';
-
-insert into job values (
-    default,
-    'http://localhost:9090/',
-    'node_cpu_seconds_total',
-    null,
-    'increase',
-    null,
-    '1h',
-    '5m',
-    'NEW',
-    null,
-    null,
-    null);

--- a/src/nostradamus.py
+++ b/src/nostradamus.py
@@ -12,7 +12,7 @@ from nostradamus.forecaster import Forecaster
 from nostradamus.database.postgres import DbController
 from nostradamus.api.exporter import Collector, MetricHandler
 
-logging.basicConfig(level=logging.DEBUG,
+logging.basicConfig(level=logging.INFO,
     format='%(asctime)s %(levelname)s [%(name)s] %(message)s')
 logger = logging.getLogger('nostradamus')
 
@@ -43,7 +43,7 @@ if __name__ == "__main__":
                       host=pg_host,
                       port=pg_port,
                       database=pg_db,
-                      pool_max_size=pg_pool)   
+                      pool_max_size=pg_pool)
     if db.ping() == 0:
         logger.info("Database connection pool initialized successfully")
 
@@ -63,12 +63,12 @@ if __name__ == "__main__":
         # Unregister default metrics
         REGISTRY.unregister(PROCESS_COLLECTOR)
         REGISTRY.unregister(PLATFORM_COLLECTOR)
-        REGISTRY.unregister(GC_COLLECTOR)  
+        REGISTRY.unregister(GC_COLLECTOR)
 
         application = tornado.web.Application([
             (r"/metrics", MetricHandler, {"ref_object": exporter})
         ])
 
         application.listen(9345)
-        logger.info("Starting Nostradamus metric exporter")        
+        logger.info("Starting Nostradamus metric exporter")
         tornado.ioloop.IOLoop.instance().start()

--- a/src/nostradamus/api/exporter.py
+++ b/src/nostradamus/api/exporter.py
@@ -7,6 +7,8 @@ from nostradamus.database.forecastcontroller import ForecastController
 from prometheus_client import generate_latest
 from prometheus_client.core import REGISTRY, GaugeMetricFamily
 
+logger = logging.getLogger('exporter')
+
 class Collector(object):
     """ Worker class """
 
@@ -25,7 +27,7 @@ class Collector(object):
         try:
             _error, forecast = self.forecast_ctrl.get_forecast()
             if _error != 0:
-                print(f'Error get_forecast. {_error}')
+                logger.error(f'Error get_forecast. {_error}')
                 return
 
             for item in forecast:
@@ -75,7 +77,7 @@ class Collector(object):
                 yield m
 
         except Exception as e:
-            print(f'Exporter failed: {e}')
+            logger.error(f'Collect method failed with: {e}')
 
 
     @staticmethod

--- a/src/nostradamus/api/exporter.py
+++ b/src/nostradamus/api/exporter.py
@@ -31,7 +31,7 @@ class Collector(object):
                 return
 
             for item in forecast:
-                metric = item['metric']
+                metric = item['metric_alias']
                 yhat = item['yhat']
                 yhat_lower = item['yhat_lower']
                 yhat_upper = item['yhat_upper']

--- a/src/nostradamus/database/forecastcontroller.py
+++ b/src/nostradamus/database/forecastcontroller.py
@@ -15,7 +15,7 @@ class ForecastController(object):
         """ TBD """
         data = []
         try:
-            query = "SELECT j.metric, f.metric_labels, \
+            query = "SELECT j.metric_alias, f.metric_labels, \
                     f.yhat, f.yhat_lower, f.yhat_upper \
                     FROM forecast f JOIN \
                         job j ON f.job_id = j.id \
@@ -45,3 +45,16 @@ class ForecastController(object):
             self.db_controller.insert_bulk(query, forecast)
         except Exception as error:
             logger(f'Failed to execute "save_forecast_bulk" method: {error}')
+
+
+    def cleanup(self, job_id, labels):
+        """ Clean """
+        query = "DELETE FROM forecast \
+        WHERE job_id=%(id)s AND ins_time<now() AND metric_labels=%(labels)s;"
+
+        args = {"id": job_id, "labels": labels}
+
+        try:
+            self.db_controller.delete(query, args)
+        except Exception as error:
+            logger.error(f'cleanup query failed with: {error}')

--- a/src/nostradamus/database/jobcontroller.py
+++ b/src/nostradamus/database/jobcontroller.py
@@ -17,12 +17,11 @@ class JobController(object):
     def get_job_by_id(self,
                       job_id):
         """ TBD """
-        query = "SELECT id, prometheus_url, metric, query_filter, \
-            range_function, optimize_function, \
-            forecast_horizon, forecast_frequency, status, \
+        query = "SELECT id, metric_alias, range_query, prometheus_url, \
+            forecast_horizon, forecast_frequency, optimize_function, status, \
             to_char(last_run,'yyyy/mm/dd hh24:mi:ss') as last_run, \
             to_char(next_run,'yyyy/mm/dd hh24:mi:ss') as next_run, \
-            last_run_duration, last_validation \
+            last_run_duration \
             FROM job \
         WHERE id = %(id)s \
         LIMIT 1;"
@@ -34,18 +33,16 @@ class JobController(object):
             if (result):
                 for row in result:
                     job = Job(id = row['id'],
+                        metric_alias = row['metric_alias'],
+                        range_query = row['range_query'],
                         prometheus_url = row['prometheus_url'],
-                        metric = row['metric'],
-                        query_filter = row['query_filter'],
-                        range_function = row['range_function'],
-                        optimize_function = row['optimize_function'],
                         forecast_horizon = row['forecast_horizon'],
                         forecast_frequency = row['forecast_frequency'],
+                        optimize_function = row['optimize_function'],
                         status = row['status'],
                         last_run = row['last_run'],
                         next_run = row['next_run'],
-                        last_run_duration = row['last_run_duration'],
-                        last_validation = row['last_validation']
+                        last_run_duration = row['last_run_duration']
                     )
                 return job
             else:
@@ -57,12 +54,11 @@ class JobController(object):
 
     def get_job(self):
         """ TBD """
-        query = "SELECT id, prometheus_url, metric, query_filter, \
-            range_function, optimize_function, \
-            forecast_horizon, forecast_frequency, status, \
+        query = "SELECT id, metric_alias, range_query, prometheus_url, \
+            forecast_horizon, forecast_frequency, optimize_function, status, \
             to_char(last_run,'yyyy/mm/dd hh24:mi:ss') as last_run, \
             to_char(next_run,'yyyy/mm/dd hh24:mi:ss') as next_run, \
-            last_run_duration, last_validation \
+            last_run_duration \
             FROM job \
         WHERE status IN ('NEW','FINISHED') \
             AND coalesce(next_run, \
@@ -77,18 +73,16 @@ class JobController(object):
             if (result):
                 for row in result:
                     job = Job(id = row['id'],
+                        metric_alias = row['metric_alias'],
+                        range_query = row['range_query'],
                         prometheus_url = row['prometheus_url'],
-                        metric = row['metric'],
-                        query_filter = row['query_filter'],
-                        range_function = row['range_function'],
-                        optimize_function = row['optimize_function'],
                         forecast_horizon = row['forecast_horizon'],
                         forecast_frequency = row['forecast_frequency'],
+                        optimize_function = row['optimize_function'],
                         status = row['status'],
                         last_run = row['last_run'],
                         next_run = row['next_run'],
-                        last_run_duration = row['last_run_duration'],
-                        last_validation = row['last_validation']
+                        last_run_duration = row['last_run_duration']
                     )
                 return job
             else:

--- a/src/nostradamus/database/postgres.py
+++ b/src/nostradamus/database/postgres.py
@@ -148,3 +148,22 @@ class DbController(object):
             conn.rollback()
             self.conn_pool.putconn(conn)
             return -1
+
+
+    def delete(self,
+               query,
+               args):
+        try:
+            params = args
+            conn = self.conn_pool.getconn()
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            cursor.close()
+            conn.commit()
+            self.conn_pool.putconn(conn)
+
+        except (Exception, psycopg2.Error) as error:
+            logger.error(f'Error executing DELETE query: {error}')
+            conn.rollback()
+            self.conn_pool.putconn(conn)
+            return -1

--- a/src/nostradamus/database/traindatacontroller.py
+++ b/src/nostradamus/database/traindatacontroller.py
@@ -24,11 +24,11 @@ class TrainDataController(object):
             result = self.db_controller.select(query, args=None)
             if (result):
                 for row in result:
-                    resp = row                    
+                    resp = row
                     #job_id = row['job_id']
                     #data = row['data']
                 #return job_id, data
-                return 0, resp                
+                return 0, resp
             else:
                 return -1, None
 
@@ -45,9 +45,9 @@ class TrainDataController(object):
             VALUES (%s, %s, %s);"
         try:
             for s in series:
-                self.db_controller.insert(query, 
-                    job_id, 
-                    "NEW", 
+                self.db_controller.insert(query,
+                    job_id,
+                    "NEW",
                     json.dumps(s)
                 )
         except Exception as e:
@@ -71,3 +71,16 @@ class TrainDataController(object):
             self.db_controller.update(query, values)
         except Exception as e:
             logger.error(f'Failed to execute "update" method: {e}')
+
+
+    def cleanup(self, job_id):
+        """ Clean """
+        query = "DELETE FROM train_data \
+        WHERE job_id = %(id)s AND ins_time<now();"
+
+        args = {"id": job_id}
+
+        try:
+            self.db_controller.delete(query, args)
+        except Exception as error:
+            logger.error(f'cleanup query failed with: {error}')

--- a/src/nostradamus/external/prometheus.py
+++ b/src/nostradamus/external/prometheus.py
@@ -114,6 +114,11 @@ class Client(object):
     def makeQuery(range_query, filter):
         """ Prepare a range query by inserting additional labels
         in the filter statement: {} """
+
+        if re.search(pattern='({.*})',string=range_query) is None:
+            query = range_query+'{'+filter+'}'
+            return query
+
         m=re.sub(pattern='}',
             repl=','+filter+'}',
             string=range_query,

--- a/src/nostradamus/external/prometheus.py
+++ b/src/nostradamus/external/prometheus.py
@@ -85,9 +85,7 @@ class Client(object):
             filters, query = '', ''
             for item in key:
                 filters = filters + f'{item}="{key[item]}",'
-
             query = self.makeQuery(self.range_query, filters)
-            logger.debug(f'----->>>>>>> {query}')
 
             # add additional required parameters for range query
             payload = {

--- a/src/nostradamus/job.py
+++ b/src/nostradamus/job.py
@@ -2,31 +2,27 @@ class Job(object):
     """ Class Job """
     def __init__(self,
                  id,
+                 metric_alias,
+                 range_query,
                  prometheus_url,
-                 metric,
-                 query_filter,
-                 range_function,
-                 optimize_function,
                  forecast_horizon,
                  forecast_frequency,
+                 optimize_function,
                  status,
                  last_run,
                  next_run,
-                 last_run_duration,
-                 last_validation):
+                 last_run_duration):
         self.id = id
+        self.metric_alias = metric_alias
+        self.range_query = range_query
         self.prometheus_url = prometheus_url
-        self.metric = metric
-        self.query_filter = query_filter
-        self.range_function = range_function
-        self.optimize_function = optimize_function
         self.forecast_horizon = forecast_horizon
         self.forecast_frequency = forecast_frequency
+        self.optimize_function = optimize_function
         self.status = status
         self.last_run = last_run
         self.next_run = next_run
         self.last_run_duration = last_run_duration
-
 
     def validate(self):
         """ Check input parameters and fill calculated fields """

--- a/src/nostradamus/metrics.py
+++ b/src/nostradamus/metrics.py
@@ -1,5 +1,59 @@
+import logging
+import tornado.web
+
+from prometheus_client import generate_latest
+from prometheus_client.core import (REGISTRY, GaugeMetricFamily,
+    CounterMetricFamily)
+
+class HealthzUpHandler(tornado.web.RequestHandler):
+    """ Tornado Handler for /healthz/metrics endpoint """
+    def __init__(self, application, request, **kwargs):
+        super().__init__(application, request, **kwargs)
+        self.logger = logging.getLogger(type(self).__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    def initialize(self, ref_object):
+        self.obj = ref_object
+
+    def get(self):
+        value = self.obj.ping()
+        self.write(value)
+
+    def on_finish(self):
+        self.obj = None
 
 
-class Metrics(object):
-    def __init__(self):
-        pass
+class HealthzReadyHandler(tornado.web.RequestHandler):
+    """ Tornado Handler for /healthz/metrics endpoint """
+    def __init__(self, application, request, **kwargs):
+        super().__init__(application, request, **kwargs)
+        self.logger = logging.getLogger(type(self).__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    def initialize(self, ref_object):
+        self.obj = ref_object
+
+    def get(self):
+        value = self.obj.ping()
+        self.write(value)
+
+    def on_finish(self):
+        self.obj = None
+
+
+class HealthzMetricHandler(tornado.web.RequestHandler):
+    """ Tornado Handler for /healthz/metrics endpoint """
+    def __init__(self, application, request, **kwargs):
+        super().__init__(application, request, **kwargs)
+        self.logger = logging.getLogger(type(self).__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    def initialize(self, ref_object):
+        self.obj = ref_object
+
+    def get(self):
+        value = self.obj.ping()
+        self.write(value)
+
+    def on_finish(self):
+        self.obj = None

--- a/src/nostradamus/models/prophet.py
+++ b/src/nostradamus/models/prophet.py
@@ -1,3 +1,4 @@
+import os
 import math
 import logging
 import fbprophet
@@ -6,11 +7,12 @@ import pandas as pd
 from datetime import datetime, timedelta
 
 logger = logging.getLogger('models.prophet')
+logger.setLevel(logging.INFO)
 
 class Prophet(object):
     """ TBD """
 
-    def __init__(self, 
+    def __init__(self,
                  train_df,
                  forecast_horizon,
                  forecast_frequency):
@@ -20,8 +22,8 @@ class Prophet(object):
         self.forecast_frequency = forecast_frequency
 
         #calculate frequency in pandas format
-        self.freq_value, self.freq_unit=self.calcUnit(self.forecast_frequency)            
-        
+        self.freq_value, self.freq_unit=self.calcUnit(self.forecast_frequency)
+
         #calculate proper periods count with specified frequency
         self.periods = self.calcPeriods(
             self.forecast_frequency,
@@ -29,7 +31,7 @@ class Prophet(object):
         )
         logger.debug(
             f'Periods:{self.periods},Freq:{self.freq_value}{self.freq_unit}'
-        )    
+        )
 
         # Choose proper growth function
         # In case of y values are below 1 then use logistic
@@ -45,31 +47,39 @@ class Prophet(object):
             floor = float(self.train_df['y'].min()) * 0.9
             p_growth = 'logistic'
             self.train_df['cap'] = cap
-            self.train_df['floor'] = floor        
+            self.train_df['floor'] = floor
         else:
             p_growth = 'linear'
         logger.debug(f'growth function: {p_growth}')
-        logger.debug(self.train_df.head(30))         
+        logger.debug(self.train_df.head(30))
 
         try:
+            logger.info(f'Creating a Prophet model with parameters: {p_growth}')
             self.model = fbprophet.Prophet(growth=p_growth)
-            self.model.fit(self.train_df)
+
+            # suppress pystan excessive logging
+            # https://github.com/facebook/prophet/issues/223
+            with suppress_stdout_stderr():
+                self.model.fit(self.train_df)
+
             self.future = self.model.make_future_dataframe(
                 periods=self.periods,
                 freq=self.freq_value+self.freq_unit
             )
             self.future['cap'] = cap
             self.future['floor'] = floor
-                
+            logger.info(f'Model was fitted successfully')
+
         except Exception as e:
-            logger.error(f'Failed to create/fit model: {e}')           
+            logger.error(f'Failed to create/fit model: {e}')
             self._failed = True
-       
+
 
     def predict(self):
         if self._failed:
             return -1, None
         try:
+            logger.info(f'Predicting future...')
             data = self.model.predict(self.future)
 
             #remove old values
@@ -82,19 +92,19 @@ class Prophet(object):
 
             #rename column
             data = data.rename(columns={'ds': 'ds_from'})
-            
+
             #calculate end of period (ds_to)
             data[['ds_to']] = data[['ds_from']] + pd.Timedelta(
-                    value=int(self.freq_value), 
+                    value=int(self.freq_value),
                     unit=self.freq_unit
                 )
 
-            #convert dataframe to dict of records            
+            #convert dataframe to dict of records
             forecast = data[['ds_from',
                 'ds_to',
                 'yhat',
                 'yhat_lower',
-                'yhat_upper']].to_dict(orient='records')  
+                'yhat_upper']].to_dict(orient='records')
 
             return 0, forecast
         except Exception as e:
@@ -110,7 +120,7 @@ class Prophet(object):
         freq_unit = freq_unit.replace('m','T')
         freq_unit = freq_unit.replace('h','H')
         freq_unit = freq_unit.replace('d','D')
-        
+
         return str(freq_val), freq_unit
 
 
@@ -118,7 +128,7 @@ class Prophet(object):
     def calcPeriods(frequency, horizon):
         freq_val = int(frequency[0:-1])
         freq_unit = frequency[-1]
-        
+
         hor_val = int(horizon[0:-1])
         hor_unit = horizon[-1]
 
@@ -128,7 +138,7 @@ class Prophet(object):
             periods = math.ceil(hor_val * 60 / freq_val)
         elif freq_unit == 'm' and hor_unit == 'd':
             periods = math.ceil(hor_val * 60 * 24 / freq_val)
-       
+
         elif freq_unit == 'h' and hor_unit == 'h':
             periods = math.ceil(hor_val / freq_val)
         elif freq_unit == 'h' and hor_unit == 'd':
@@ -144,3 +154,33 @@ class Prophet(object):
             periods = -1
 
         return periods
+
+
+class suppress_stdout_stderr(object):
+    '''
+    A context manager for doing a "deep suppression" of stdout and stderr in
+    Python, i.e. will suppress all print, even if the print originates in a
+    compiled C/Fortran sub-function.
+       This will not suppress raised exceptions, since exceptions are printed
+    to stderr just before a script exits, and after the context manager has
+    exited (at least, I think that is why it lets exceptions through).
+
+    '''
+    def __init__(self):
+        # Open a pair of null files
+        self.null_fds = [os.open(os.devnull, os.O_RDWR) for x in range(2)]
+        # Save the actual stdout (1) and stderr (2) file descriptors.
+        self.save_fds = [os.dup(1), os.dup(2)]
+
+    def __enter__(self):
+        # Assign the null pointers to stdout and stderr.
+        os.dup2(self.null_fds[0], 1)
+        os.dup2(self.null_fds[1], 2)
+
+    def __exit__(self, *_):
+        # Re-assign the real stdout/stderr back to (1) and (2)
+        os.dup2(self.save_fds[0], 1)
+        os.dup2(self.save_fds[1], 2)
+        # Close the null files
+        for fd in self.null_fds + self.save_fds:
+            os.close(fd)

--- a/src/nostradamus/worker.py
+++ b/src/nostradamus/worker.py
@@ -40,10 +40,9 @@ class Worker(object):
             return
 
         self.job_ctrl.update_job(task.id, status='FETCHING', last_run='now()')
-        api_client = PrometheusClient(task.prometheus_url,
-                                      task.metric,
-                                      task.query_filter,
-                                      task.range_function,
+        api_client = PrometheusClient(task.metric_alias,
+                                      task.range_query,
+                                      task.prometheus_url,
                                       task.forecast_horizon,
                                       task.forecast_frequency)
         error, series = api_client.getSeries()


### PR DESCRIPTION
1. Switched to range_queries in all cases. That's useful if there is a need to handle counter typed metrics or calculate aggregations, like sum(increase); Filter clause {} is mandatory if any functions used in range_query.
2. Added cleanup of previous worker/forecaster runs in train_data/forecast tables;
3. Suppressed pystan logging in prophet module;
4. Fixed logging in main modules;

